### PR TITLE
Dockerfile: Use busybox for libc support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/static:latest
+FROM busybox
 USER root
 
 COPY gpu-metrics-agent /gpu-metrics-agent


### PR DESCRIPTION
chainguard's image has no libc. We need libc here. Using busybox fixes this.