### PR TITLE
Use debian:stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox:glibc
+FROM debian:stable
 USER root
 
 COPY gpu-metrics-agent /gpu-metrics-agent


### PR DESCRIPTION
It's still unable to find `libdl.so.2`. 
Let's use `debian:stable` until we have to figure out something different...