### PR TITLE
nvidia_mock: Track last time per device

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/NVIDIA/go-nvml v0.12.4-0
 	github.com/alecthomas/kong v1.5.1
 	github.com/google/uuid v1.6.0
+	github.com/oklog/run v1.1.0
 	github.com/open-telemetry/otel-arrow v0.31.0
 	github.com/parca-dev/parca-agent v0.35.0
 	github.com/prometheus/client_golang v1.20.5
@@ -41,7 +42,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/oklog/run v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect


### PR DESCRIPTION
We only tracked one lastTime and it caused only one device to ever get metrics generated for and the other two were empty.

Now we get consistently series for 3 devices with their UUID and index plus same amount of metrics for each.
