### PR TITLE
nvidia_mock: Mock gpu utilization, memory and power

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -113,7 +113,7 @@ func (e *Exporter) report(ctx context.Context) error {
 			e.stream = nil
 			continue
 		} else {
-			slog.Warn("Send succeeded", "data points", dpc)
+			slog.Info("Send succeeded", "data points", dpc)
 		}
 		break
 	}

--- a/nvidia.go
+++ b/nvidia.go
@@ -16,7 +16,7 @@ import (
 const (
 	attributeIndex                        = "index"
 	attributeUUID                         = "uuid"
-	metricNameGPUMemoryUtilizationPercent = "gpu_utilization_memory_percent"
+	metricNameGPUUtilizationMemoryPercent = "gpu_utilization_memory_percent"
 	metricNameGPUUtilizationPercent       = "gpu_utilization_percent"
 	metricNameGPUPowerWatt                = "gpu_power_watt"
 )
@@ -122,7 +122,7 @@ func (p *producer) produceUtilization(pds perDeviceState, uuid string, index int
 func (p *producer) produceMemoryUtilization(pds perDeviceState, uuid string, index int, ms pmetric.MetricSlice) error {
 	m := ms.AppendEmpty()
 	g := m.SetEmptyGauge()
-	m.SetName(metricNameGPUMemoryUtilizationPercent)
+	m.SetName(metricNameGPUUtilizationMemoryPercent)
 
 	sampleType, samples, ret := pds.d.GetSamples(nvml.MEMORY_UTILIZATION_SAMPLES, pds.lastTimestamp)
 	if !errors.Is(ret, nvml.SUCCESS) {

--- a/nvidia_mock.go
+++ b/nvidia_mock.go
@@ -12,6 +12,20 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
+// Mock data extract from a real world PyTorch.
+var (
+	mockData = map[string][]int64{
+		metricNameGPUPowerWatt:                {69382, 69382, 69382, 73170, 73170, 73170, 75577, 75577, 75577, 69218, 69218, 69218, 73523, 73523, 73523, 46365, 46365, 46365, 73285, 73285, 73285, 74602, 74602, 74602, 66618, 66618, 66618, 72183, 72183, 72183},
+		metricNameGPUUtilizationMemoryPercent: {0, 57, 57, 53, 54, 53, 57, 13, 46, 55, 57, 53, 56, 54, 52, 12, 55, 54, 54, 55, 56, 54, 3, 30, 55, 56, 58, 55, 53, 0},
+		metricNameGPUUtilizationPercent:       {3, 70, 70, 65, 67, 65, 70, 17, 57, 67, 70, 66, 69, 67, 64, 15, 68, 67, 66, 68, 69, 67, 4, 37, 67, 69, 72, 67, 65, 0},
+	}
+	mockDataIdle = map[string]int64{
+		metricNameGPUPowerWatt:                6123, // idle at ~6W
+		metricNameGPUUtilizationMemoryPercent: 0,
+		metricNameGPUUtilizationPercent:       0,
+	}
+)
+
 type MockProducer struct {
 	deviceLastTime map[string]time.Time
 }
@@ -33,35 +47,41 @@ func (p *MockProducer) Produce(ms pmetric.MetricSlice) error {
 	deviceIDs := slices.Sorted(maps.Keys(p.deviceLastTime)) // Maps are unsorted, so we get its keys and sort
 
 	for i, id := range deviceIDs {
-		slog.Info("Collecting metrics for device", "uuid", id, "index", i)
-
-		m := ms.AppendEmpty()
-		g := m.SetEmptyGauge()
-
-		now := time.Now()
-		m.SetName("gpu_utilization_percent")
-
-		// Create jitter based on the uuid so metrics values don't overlap.
-		h := fnv.New32a()
-		_, _ = h.Write([]byte(id))
-		jitter := int64(h.Sum32() % 100)
+		slog.Info("Collecting metrics for device", attributeUUID, id, attributeIndex, i)
 
 		lastTimeRounded := p.deviceLastTime[id].Truncate(PERIOD).Add(PERIOD)
+		now := time.Now()
 
-		for lastTimeRounded.Before(now) {
-			// This will make the value go up and down between 0 and 100 based on the timestamp's seconds.
-			v := (lastTimeRounded.Unix() - jitter) % 200
-			if v > 100 {
-				v = 200 - v
+		for metricName, samples := range mockData {
+			m := ms.AppendEmpty()
+			g := m.SetEmptyGauge()
+
+			m.SetName(metricName)
+
+			// Create jitter based on the uuid so metrics values don't overlap.
+			h := fnv.New32a()
+			_, _ = h.Write([]byte(id))
+			jitter := int64(h.Sum32() % 100)
+
+			metricLastTime := lastTimeRounded
+
+			for metricLastTime.Before(now) {
+				mockDataIndex := (metricLastTime.Unix() - jitter) % 60
+				var v int64
+				if mockDataIndex < 30 {
+					v = samples[mockDataIndex]
+				} else {
+					v = mockDataIdle[metricName]
+				}
+
+				dp := g.DataPoints().AppendEmpty()
+				dp.Attributes().PutStr(attributeUUID, id)
+				dp.Attributes().PutInt(attributeIndex, int64(i))
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(metricLastTime))
+				dp.SetIntValue(v)
+
+				metricLastTime = metricLastTime.Add(PERIOD)
 			}
-
-			dp := g.DataPoints().AppendEmpty()
-			dp.Attributes().PutStr("UUID", id)
-			dp.Attributes().PutInt("index", int64(i))
-			dp.SetTimestamp(pcommon.NewTimestampFromTime(lastTimeRounded))
-			dp.SetIntValue(v)
-
-			lastTimeRounded = lastTimeRounded.Add(PERIOD)
 		}
 		p.deviceLastTime[id] = now
 	}


### PR DESCRIPTION
This data is from a real run of PyTorch and exported into a format that we can iterate over it indefinitely.

Each series will be "active" for 30s and then idle for 30s. Repeating every 60s.
