### PR TITLE
Add .golangci.yml and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+run:
+  deadline: 15m
+
+linters:
+  enable:
+    - depguard
+    - godot
+    - gofumpt
+    - goimports
+    - revive
+    - unused
+    - whitespace
+
+issues:
+  exclude-rules:
+    - path: _test.go
+      linters:
+        - errcheck
+
+linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    rules:
+      main:
+        list-mode: lax
+        allow:
+          - $gostd
+    packages-with-error-message:
+      - sync/atomic: "Use go.uber.org/atomic instead of sync/atomic"
+      - github.com/stretchr/testify/assert: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
+      - github.com/go-kit/kit/log: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
+      - github.com/pkg/errors: "Use fmt.Errorf instead"
+  goimports:
+    local-prefixes: github.com/polarsignals/gpu-metrics-agent
+  gofumpt:
+    extra-rules: true
+  misspell:
+    locale: US

--- a/exporter.go
+++ b/exporter.go
@@ -89,7 +89,7 @@ func (e *Exporter) report(ctx context.Context) error {
 	var err error
 	var arrow *arrowpb.BatchArrowRecords
 	for retriesRemaining >= 0 {
-		retriesRemaining -= 1
+		retriesRemaining--
 		if e.stream == nil {
 			err = e.makeStream(ctx)
 			if err != nil {
@@ -112,9 +112,8 @@ func (e *Exporter) report(ctx context.Context) error {
 			slog.Warn("Error on send", "error", err)
 			e.stream = nil
 			continue
-		} else {
-			slog.Info("Send succeeded", "data points", dpc)
 		}
+		slog.Info("Send succeeded", "data points", dpc)
 		break
 	}
 
@@ -128,7 +127,7 @@ func (e *Exporter) report(ctx context.Context) error {
 func (e *Exporter) Start(ctx context.Context) error {
 	slog.Info("running arrow metrics exporter", "producers", len(e.producers))
 	if len(e.producers) == 0 {
-		return errors.New("No producers configured")
+		return errors.New("no producers configured")
 	}
 	tick := time.NewTicker(e.interval)
 	defer tick.Stop()
@@ -138,7 +137,7 @@ func (e *Exporter) Start(ctx context.Context) error {
 			return nil
 		case <-tick.C:
 			if err := e.report(ctx); err != nil {
-				fmt.Errorf("Failed to send arrow metrics: %v", err)
+				return fmt.Errorf("failed to send arrow metrics: %v", err)
 			}
 			tick.Reset(libpf.AddJitter(e.interval, 0.2))
 		}

--- a/flags.go
+++ b/flags.go
@@ -16,7 +16,7 @@ const (
 	ExitSuccess ExitCode = 0
 	ExitFailure ExitCode = 1
 
-	// Go 'flag' package calls os.Exit(2) on flag parse errors, if ExitOnError is set
+	// Go 'flag' package calls os.Exit(2) on flag parse errors, if ExitOnError is set.
 	ExitParseError ExitCode = 2
 )
 
@@ -42,7 +42,7 @@ type FlagsLogs struct {
 	Format string `default:"logfmt" enum:"logfmt,json"           help:"Configure if structured logging as JSON or as logfmt"`
 }
 
-// slogHandler returns a non-nil slog.Handler based on the log flags
+// slogHandler returns a non-nil slog.Handler based on the log flags.
 func (f FlagsLogs) slogHandler() slog.Handler {
 	level := slog.LevelInfo
 	switch f.Level {

--- a/main.go
+++ b/main.go
@@ -132,7 +132,6 @@ func mainWithExitCode() ExitCode {
 			Producer:  mock,
 			ScopeName: scopeName,
 		})
-
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	var g run.Group


### PR DESCRIPTION
Renamed `producer` to `NvidiaProducer` for clarity and updated error message formatting in Nvidia-related functions. Added `.golangci.yml` to enforce coding standards and fixed minor code style issues, including streamlining conditional blocks and correcting comments punctuation.
