### PR TITLE
Use `CollectionInterval` for metrics collection frequency.

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -25,11 +25,11 @@ func Failure(msg string, args ...interface{}) ExitCode {
 }
 
 type Flags struct {
-	Version           bool          `help:"Show application version."`
-	Log               FlagsLogs     `embed:""                         prefix:"log-"`
-	Node              string        `default:"${hostname}"               help:"The name of the node that the process is running on. If on Kubernetes, this must match the Kubernetes node name."`
-	ClockSyncInterval time.Duration `default:"3m" help:"How frequently to synchronize with the realtime clock."`
+	Version bool      `help:"Show application version."`
+	Log     FlagsLogs `embed:""                         prefix:"log-"`
+	Node    string    `default:"${hostname}"               help:"The name of the node that the process is running on. If on Kubernetes, this must match the Kubernetes node name."`
 
+	CollectionInterval time.Duration `default:"10s" help:"Interval between collection cycles."`
 	// which metrics producers (e.g. nvidia) to enable
 	MetricsProducer FlagsMetricProducer `embed:"" prefix:"metrics-producer-"`
 	RemoteStore     FlagsRemoteStore    `embed:"" prefix:"remote-store-"`

--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func mainWithExitCode() ExitCode {
 	defer grpcConn.Close()
 
 	arrowClient := arrowpb.NewArrowMetricsServiceClient(grpcConn)
-	arrowMetricsExporter := NewExporter(arrowClient, time.Second*10, map[string]any{"node": f.Node})
+	arrowMetricsExporter := NewExporter(arrowClient, f.CollectionInterval, map[string]any{"node": f.Node})
 	const nvidiaMetricsScopeName = "parca.nvidia_gpu_metrics"
 	if f.MetricsProducer.NvidiaGpu {
 		nvidia, err := NewNvidiaProducer()


### PR DESCRIPTION
Replaced the hardcoded 10-second interval with the configurable `CollectionInterval` flag, enhancing flexibility. Added the `CollectionInterval` field to the `Flags` struct with a default value of 10 seconds. This allows users to customize the collection cycle duration.
