### PR TITLE
nvidia: Collect per-process utilization metrics 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	go.opentelemetry.io/collector/pdata v1.28.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1
-	go.opentelemetry.io/ebpf-profiler v0.0.0-20241025131851-7fa5b1e60d38
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
 	google.golang.org/grpc v1.71.0

--- a/grpc.go
+++ b/grpc.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	tracing "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
@@ -30,7 +29,7 @@ import (
 // WaitGrpcEndpoint waits until the gRPC connection is established.
 func (f FlagsRemoteStore) WaitGrpcEndpoint(ctx context.Context, reg prometheus.Registerer, tp trace.TracerProvider) (*grpc.ClientConn, error) {
 	// Sleep with a fixed backoff time added of +/- 20% jitter
-	tick := time.NewTicker(libpf.AddJitter(f.GRPCStartupBackoffTime, 0.2))
+	tick := time.NewTicker(addJitter(f.GRPCStartupBackoffTime, 0.2))
 	defer tick.Stop()
 
 	// metrics

--- a/nvidia.go
+++ b/nvidia.go
@@ -473,11 +473,21 @@ func (ds *perDeviceState) collectProcessUtilization() error {
 	for _, process := range computeProcesses {
 		utilization, ret := ds.d.GetProcessUtilization(uint64(process.Pid))
 		if !errors.Is(ret, nvml.SUCCESS) {
+			// If the process is not found (likely terminated), skip it and continue
+			if errors.Is(ret, nvml.ERROR_NOT_FOUND) {
+				slog.Debug("process not found, skipping", "pid", process.Pid, "error", nvml.ErrorString(ret))
+				continue
+			}
 			return fmt.Errorf("failed to get process utilization for %d - pid: %d - %s", ds.index, process.Pid, nvml.ErrorString(ret))
 		}
 
 		processName, ret := nvml.SystemGetProcessName(int(process.Pid)) // could easily be cached
 		if !errors.Is(ret, nvml.SUCCESS) {
+			// If the process is not found (likely terminated), skip it and continue
+			if errors.Is(ret, nvml.ERROR_NOT_FOUND) {
+				slog.Debug("process not found, skipping", "pid", process.Pid, "error", nvml.ErrorString(ret))
+				continue
+			}
 			return fmt.Errorf("failed to get process name for %d - pid: %d - %s", ds.index, process.Pid, nvml.ErrorString(ret))
 		}
 

--- a/nvidia.go
+++ b/nvidia.go
@@ -98,6 +98,8 @@ func NewNvidiaProducer() (*NvidiaProducer, error) {
 }
 
 func (p *NvidiaProducer) Collect(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+
 	var group run.Group
 
 	{
@@ -128,6 +130,7 @@ func (p *NvidiaProducer) Collect(ctx context.Context) error {
 				}
 			}
 		}, func(err error) {
+			cancel()
 		})
 	}
 	{
@@ -149,9 +152,11 @@ func (p *NvidiaProducer) Collect(ctx context.Context) error {
 							return err
 						}
 					}
+
 				}
 			}
 		}, func(err error) {
+			cancel()
 		})
 	}
 	{
@@ -176,6 +181,7 @@ func (p *NvidiaProducer) Collect(ctx context.Context) error {
 				}
 			}
 		}, func(err error) {
+			cancel()
 		})
 	}
 	{
@@ -200,6 +206,7 @@ func (p *NvidiaProducer) Collect(ctx context.Context) error {
 				}
 			}
 		}, func(err error) {
+			cancel()
 		})
 	}
 	{
@@ -224,6 +231,7 @@ func (p *NvidiaProducer) Collect(ctx context.Context) error {
 				}
 			}
 		}, func(err error) {
+			cancel()
 		})
 	}
 	{
@@ -248,11 +256,11 @@ func (p *NvidiaProducer) Collect(ctx context.Context) error {
 				}
 			}
 		}, func(err error) {
+			cancel()
 		})
 	}
 
-	err := group.Run()
-	return err
+	return group.Run()
 }
 
 func (p *NvidiaProducer) Produce(ms pmetric.MetricSlice) error {
@@ -455,7 +463,11 @@ func (ds *perDeviceState) collectProcessUtilization() error {
 		return nil
 	}
 
-	slog.Debug("compute processes running", "count", len(computeProcesses))
+	pids := make([]uint32, len(computeProcesses))
+	for i, p := range computeProcesses {
+		pids[i] = p.Pid
+	}
+	slog.Debug("compute processes running", "pids", pids)
 
 	// Add data points for each process
 	for _, process := range computeProcesses {


### PR DESCRIPTION
- **Remove unused ebpf-profiler dependency and related references**
- **Add process-level GPU utilization metrics collection**
