### PR TITLE
*: add dcgm metrics to agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,10 @@ jobs:
         id: vars
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
         run: |
-          echo "tag=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          # Docker tags can't contain '/', so flatten branch names with slashes.
+          branch=$(echo "$branch" | tr '/' '-')
+          echo "tag=${branch}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "git_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
 
       - name: Push snapshot images

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Track GPU performance during model training and inference. Ensure optimal resour
 | `gpu_temperature_celsius` | GPU temperature | 1s |
 | `gpu_pcie_throughput_transmit_bytes` | PCIe transmit throughput | 100ms |
 | `gpu_pcie_throughput_receive_bytes` | PCIe receive throughput | 100ms |
+| `gpu_prof_dram_active` | Fraction of time the GPU memory interface is active (0..1). Requires `--metrics-producer-dcgm-profiling`. | 1s |
+| `gpu_prof_sm_active` | Fraction of time ≥1 warp is active on an SM (0..1). Requires `--metrics-producer-dcgm-profiling`. | 1s |
+| `gpu_prof_sm_occupancy` | Fraction of SM warp slots occupied (0..1). Requires `--metrics-producer-dcgm-profiling`. | 1s |
+| `gpu_prof_pipe_tensor_active` | Tensor-core pipe issue fraction (0..1). Requires `--metrics-producer-dcgm-profiling`. | 1s |
+| `gpu_prof_pipe_fp64_active` | FP64 pipe issue fraction (0..1). Requires `--metrics-producer-dcgm-profiling`. | 1s |
+| `gpu_prof_pipe_fp32_active` | FP32 pipe issue fraction (0..1). Requires `--metrics-producer-dcgm-profiling`. | 1s |
+| `gpu_prof_pipe_fp16_active` | FP16 pipe issue fraction (0..1). Requires `--metrics-producer-dcgm-profiling`. | 1s |
 
 All metrics include `uuid` (GPU identifier) and `index` (GPU index) attributes. Process-level metrics also include `pid` and `comm` attributes.
 
@@ -87,6 +94,7 @@ docker run -it --rm \
 |------|-------------|---------|
 | `--remote-store-address` | gRPC endpoint for metric storage | Required |
 | `--metrics-producer-nvidia-gpu` | Enable NVIDIA GPU metrics | false |
+| `--metrics-producer-dcgm-profiling` | Enable DCGM profiling metrics (DRAM bandwidth, SM/pipe activity). See [DCGM profiling](#dcgm-profiling-optional) below. | false |
 | `--collection-interval` | Metric export interval | 10s |
 | `--node` | Node name for metric labeling | Machine ID |
 | `--bearer-token` | Authentication token | - |
@@ -111,6 +119,20 @@ The agent consists of three main components:
 - NVIDIA GPU with driver version 390.x or newer
 - Linux operating system
 - NVIDIA Management Library (NVML) available
+
+### DCGM profiling (optional)
+
+Setting `--metrics-producer-dcgm-profiling=true` loads `libdcgm.so` in-process (DCGM *embedded* mode — no separate `nv-hostengine` daemon). While enabled, the agent acquires the GPU's PerfWorks counter subsystem **exclusively**: NVIDIA Nsight Compute (`ncu`) and any CUPTI Profiling API clients on the same GPU will fail to start. The CUPTI callback API used for kernel-launch tracing (Parca GPU profiler / `libparcagpucupti.so`) is unaffected.
+
+Multiply the `gpu_prof_dram_active` fraction by the GPU's peak memory bandwidth (e.g. L4 = 300 GB/s, A100 = 1.55 TB/s, H100 = 3.35 TB/s) to get sustained bandwidth in bytes/sec.
+
+`libdcgm.so` is not bundled in the container image — like `libnvidia-ml.so`, it must be supplied at runtime. The simplest options:
+
+- **NVIDIA Container Toolkit / CDI**: configure the CDI spec to inject `libdcgm.so.*` from the host (the host needs `datacenter-gpu-manager` installed, e.g. `apt install datacenter-gpu-manager` on Debian/Ubuntu).
+- **Bind mount**: `-v /usr/lib/x86_64-linux-gnu/libdcgm.so.3:/usr/lib/x86_64-linux-gnu/libdcgm.so.3` (or the equivalent aarch64 path).
+- **Build from source**: install `libdcgm` on the target host directly.
+
+If `libdcgm.so` cannot be loaded the agent will exit with `Failed to instantiate DCGM profiling producer: ... Is libdcgm.so present and the NVIDIA driver loaded?`.
 
 ## Building from Source
 

--- a/dcgm_linux.go
+++ b/dcgm_linux.go
@@ -1,0 +1,246 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const (
+	metricNameGPUProfDRAMActive       = "gpu_prof_dram_active"
+	metricNameGPUProfSMActive         = "gpu_prof_sm_active"
+	metricNameGPUProfSMOccupancy      = "gpu_prof_sm_occupancy"
+	metricNameGPUProfPipeTensorActive = "gpu_prof_pipe_tensor_active"
+	metricNameGPUProfPipeFP64Active   = "gpu_prof_pipe_fp64_active"
+	metricNameGPUProfPipeFP32Active   = "gpu_prof_pipe_fp32_active"
+	metricNameGPUProfPipeFP16Active   = "gpu_prof_pipe_fp16_active"
+
+	dcgmPollInterval      = 1 * time.Second
+	dcgmUpdateFreqUs      = int64(100_000) // 100 ms backend sampling
+	dcgmMaxKeepAgeSeconds = float64(3600)
+	dcgmMaxKeepSamples    = int32(0) // 0 = keep all within maxKeepAge
+	dcgmFieldGroupName    = "gpu-metrics-agent-prof"
+)
+
+// dcgmProfFields maps DCGM profiling field IDs to metric names.
+// Values are fractions in [0, 1]; multiply by peak per-GPU spec to get absolute rates.
+var dcgmProfFields = map[dcgm.Short]string{
+	dcgm.DCGM_FI_PROF_DRAM_ACTIVE:        metricNameGPUProfDRAMActive,
+	dcgm.DCGM_FI_PROF_SM_ACTIVE:          metricNameGPUProfSMActive,
+	dcgm.DCGM_FI_PROF_SM_OCCUPANCY:       metricNameGPUProfSMOccupancy,
+	dcgm.DCGM_FI_PROF_PIPE_TENSOR_ACTIVE: metricNameGPUProfPipeTensorActive,
+	dcgm.DCGM_FI_PROF_PIPE_FP64_ACTIVE:   metricNameGPUProfPipeFP64Active,
+	dcgm.DCGM_FI_PROF_PIPE_FP32_ACTIVE:   metricNameGPUProfPipeFP32Active,
+	dcgm.DCGM_FI_PROF_PIPE_FP16_ACTIVE:   metricNameGPUProfPipeFP16Active,
+}
+
+type DcgmProducer struct {
+	cleanup      func()
+	fieldIDs     []dcgm.Short
+	fieldGroupID dcgm.FieldHandle
+	devices      []*dcgmPerDeviceState
+}
+
+type dcgmPerDeviceState struct {
+	gpuID uint
+	uuid  string
+
+	mu          *sync.RWMutex
+	gauges      map[string]pmetric.Gauge
+	unsupported map[dcgm.Short]bool
+}
+
+func NewDcgmProducer() (_ *DcgmProducer, retErr error) {
+	slog.Warn("DCGM profiling producer enabled: acquires GPU PerfWorks counters exclusively; ncu and CUPTI profiling API on the same GPU will fail while this is running")
+
+	shutdown, err := dcgm.Init(dcgm.Embedded)
+	if err != nil {
+		return nil, fmt.Errorf("dcgm.Init(Embedded) failed: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			shutdown()
+		}
+	}()
+
+	gpuIDs, err := dcgm.GetSupportedDevices()
+	if err != nil {
+		return nil, fmt.Errorf("dcgm.GetSupportedDevices failed: %w", err)
+	}
+	if len(gpuIDs) == 0 {
+		return nil, fmt.Errorf("no DCGM-supported GPUs found")
+	}
+
+	devices := make([]*dcgmPerDeviceState, 0, len(gpuIDs))
+	for _, gpuID := range gpuIDs {
+		info, err := dcgm.GetDeviceInfo(gpuID)
+		if err != nil {
+			return nil, fmt.Errorf("dcgm.GetDeviceInfo(%d) failed: %w", gpuID, err)
+		}
+		devices = append(devices, &dcgmPerDeviceState{
+			gpuID:       gpuID,
+			uuid:        info.UUID,
+			mu:          &sync.RWMutex{},
+			gauges:      map[string]pmetric.Gauge{},
+			unsupported: map[dcgm.Short]bool{},
+		})
+	}
+
+	fieldIDs := make([]dcgm.Short, 0, len(dcgmProfFields))
+	for id := range dcgmProfFields {
+		fieldIDs = append(fieldIDs, id)
+	}
+
+	fieldGroupID, err := dcgm.FieldGroupCreate(dcgmFieldGroupName, fieldIDs)
+	if err != nil {
+		return nil, fmt.Errorf("dcgm.FieldGroupCreate failed: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			_ = dcgm.FieldGroupDestroy(fieldGroupID)
+		}
+	}()
+
+	if err := dcgm.WatchFieldsWithGroupEx(
+		fieldGroupID,
+		dcgm.GroupAllGPUs(),
+		dcgmUpdateFreqUs,
+		dcgmMaxKeepAgeSeconds,
+		dcgmMaxKeepSamples,
+	); err != nil {
+		return nil, fmt.Errorf("dcgm.WatchFieldsWithGroupEx failed: %w", err)
+	}
+
+	return &DcgmProducer{
+		cleanup: func() {
+			_ = dcgm.UnwatchFields(fieldGroupID, dcgm.GroupAllGPUs())
+			_ = dcgm.FieldGroupDestroy(fieldGroupID)
+			shutdown()
+		},
+		fieldIDs:     fieldIDs,
+		fieldGroupID: fieldGroupID,
+		devices:      devices,
+	}, nil
+}
+
+func (p *DcgmProducer) Close() {
+	if p.cleanup != nil {
+		p.cleanup()
+	}
+}
+
+func (p *DcgmProducer) Collect(ctx context.Context) error {
+	ticker := time.NewTicker(dcgmPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			for _, pds := range p.devices {
+				if err := pds.sample(p.fieldIDs); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+// isBlankFloat64 returns true if the value is one of DCGM's FP64 sentinel
+// markers (BLANK, NOT_FOUND, NOT_SUPPORTED, NOT_PERMISSIONED), all of which
+// are >= DCGM_FT_FP64_BLANK and well above any legitimate 0..1 fraction.
+func isBlankFloat64(v float64) bool {
+	return v >= dcgm.DCGM_FT_FP64_BLANK
+}
+
+func (ds *dcgmPerDeviceState) sample(fieldIDs []dcgm.Short) error {
+	values, err := dcgm.GetLatestValuesForFields(ds.gpuID, fieldIDs)
+	if err != nil {
+		return fmt.Errorf("dcgm.GetLatestValuesForFields(gpu=%d) failed: %w", ds.gpuID, err)
+	}
+
+	ts := time.Now()
+	for _, fv := range values {
+		metricName, ok := dcgmProfFields[fv.FieldID]
+		if !ok {
+			continue
+		}
+
+		ds.mu.RLock()
+		skipped := ds.unsupported[fv.FieldID]
+		ds.mu.RUnlock()
+		if skipped {
+			continue
+		}
+
+		if fv.Status != 0 {
+			slog.Warn("DCGM field unsupported on device; excluding from future samples",
+				"gpu", ds.gpuID, "uuid", ds.uuid, "field", metricName, "status", fv.Status)
+			ds.mu.Lock()
+			ds.unsupported[fv.FieldID] = true
+			ds.mu.Unlock()
+			continue
+		}
+
+		value := fv.Float64()
+		if isBlankFloat64(value) {
+			slog.Warn("DCGM field returned blank value on device; excluding from future samples",
+				"gpu", ds.gpuID, "uuid", ds.uuid, "field", metricName, "value", value)
+			ds.mu.Lock()
+			ds.unsupported[fv.FieldID] = true
+			ds.mu.Unlock()
+			continue
+		}
+
+		g := pmetric.NewGauge()
+		dp := g.DataPoints().AppendEmpty()
+		dp.Attributes().PutStr(attributeUUID, ds.uuid)
+		dp.Attributes().PutInt(attributeIndex, int64(ds.gpuID))
+		dp.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+		dp.SetDoubleValue(value)
+
+		ds.appendGauge(metricName, g)
+	}
+
+	return nil
+}
+
+func (ds *dcgmPerDeviceState) appendGauge(metricName string, g pmetric.Gauge) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	if existing, found := ds.gauges[metricName]; found {
+		g.DataPoints().MoveAndAppendTo(existing.DataPoints())
+	} else {
+		ds.gauges[metricName] = g
+	}
+}
+
+func (p *DcgmProducer) Produce(ms pmetric.MetricSlice) error {
+	for _, device := range p.devices {
+		device.mu.Lock()
+		for metricName, gauge := range device.gauges {
+			m := ms.AppendEmpty()
+			m.SetName(metricName)
+			m.SetEmptyGauge()
+			if gauge.DataPoints().Len() > 0 {
+				slog.Debug("producing metric",
+					"metric", metricName,
+					"data points", gauge.DataPoints().Len(),
+				)
+				gauge.MoveTo(m.Gauge())
+			}
+		}
+		device.mu.Unlock()
+	}
+	return nil
+}

--- a/dcgm_other.go
+++ b/dcgm_other.go
@@ -1,0 +1,27 @@
+//go:build !linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// DcgmProducer is a stub for non-Linux platforms. libdcgm is Linux-only.
+type DcgmProducer struct{}
+
+func NewDcgmProducer() (*DcgmProducer, error) {
+	return nil, fmt.Errorf("DCGM profiling producer is only supported on Linux")
+}
+
+func (p *DcgmProducer) Close() {}
+
+func (p *DcgmProducer) Collect(_ context.Context) error {
+	return fmt.Errorf("DCGM profiling producer is only supported on Linux")
+}
+
+func (p *DcgmProducer) Produce(_ pmetric.MetricSlice) error {
+	return nil
+}

--- a/flags.go
+++ b/flags.go
@@ -101,6 +101,7 @@ func (f FlagsLogs) ConfigureLogger() {
 type FlagsMetricProducer struct {
 	NvidiaGpu     bool `default:"false" help:"Collect metrics related to Nvidia GPUs."`
 	NvidiaGpuMock bool `default:"false" help:"Generate fake Nvidia GPU metrics." hidden:""`
+	DcgmProfiling bool `default:"false" help:"Collect DCGM profiling metrics (DRAM/SM/pipe active fractions). Acquires GPU PerfWorks counters exclusively — disables ncu and CUPTI profiling API on the same GPU while running."`
 }
 
 func Parse() (Flags, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/polarsignals/gpu-metrics-agent
 go 1.23.2
 
 require (
+	github.com/NVIDIA/go-dcgm v0.0.0-20260429173627-9838af5ee300
 	github.com/NVIDIA/go-nvml v0.12.4-1
 	github.com/alecthomas/kong v1.9.0
 	github.com/gogo/protobuf v1.3.2
@@ -22,6 +23,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bits-and-blooms/bitset v1.22.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -34,6 +36,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -41,4 +44,5 @@ require (
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go/compute v1.23.4 h1:EBT9Nw4q3zyE7G45Wvv3MzolIrCJEuHys5muLY0wvAw=
 cloud.google.com/go/compute/metadata v0.6.0 h1:A6hENjEsCDtC1k8byVsgwvVcioamEHvZ4j01OwKxG9I=
 cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1FlqW3Rga40jzHL4hfg=
+github.com/NVIDIA/go-dcgm v0.0.0-20260429173627-9838af5ee300 h1:92Z3JKOx6EmCOs9gTFpaBdUM9kXA28e4Te6Ns7a9B58=
+github.com/NVIDIA/go-dcgm v0.0.0-20260429173627-9838af5ee300/go.mod h1:cA0Bv7+JtAd8sqCCZizhAQjj4+Z47x/d8KD60iYBT+g=
 github.com/NVIDIA/go-nvml v0.12.4-1 h1:WKUvqshhWSNTfm47ETRhv0A0zJyr1ncCuHiXwoTrBEc=
 github.com/NVIDIA/go-nvml v0.12.4-1/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
@@ -11,6 +13,8 @@ github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=
+github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3 h1:boJj011Hh+874zpIySeApCX4GeOjPl9qhRF3QuIZq+Q=
@@ -47,6 +51,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -69,6 +77,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -139,6 +149,8 @@ google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -130,6 +130,17 @@ func mainWithExitCode() ExitCode {
 			ScopeName: scopeName,
 		})
 	}
+	if f.MetricsProducer.DcgmProfiling {
+		dcgmProd, err := NewDcgmProducer()
+		if err != nil {
+			return Failure("Failed to instantiate DCGM profiling producer: %v. Is libdcgm.so present and the NVIDIA driver loaded?", err)
+		}
+		defer dcgmProd.Close()
+		metricsExporter.AddProducer(ProducerConfig{
+			Producer:  dcgmProd,
+			ScopeName: "parca.nvidia_gpu_dcgm_metrics",
+		})
+	}
 	ctx, cancel := context.WithCancel(ctx)
 	var g run.Group
 	g.Add(func() error {


### PR DESCRIPTION
Adds DcgmProducer (enabled via --metrics-producer-dcgm-profiling, default off). DCGM runs embedded (no nv-hostengine); 1 Hz poll, 100 ms backend updateFreq; float64 [0, 1] gauges under scope parca.nvidia_gpu_dcgm_metrics with uuid/index attributes. NVML has no DRAM bandwidth field -- gpu_prof_dram_active x peak (L4 = 300 GB/s, A100 = 1.55 TB/s, H100 = 3.35 TB/s) gives bytes/sec.

Metrics, all sourced from DCGM_FI_PROF_* fields:
  gpu_prof_dram_active, gpu_prof_sm_active, gpu_prof_sm_occupancy,
  gpu_prof_pipe_{tensor,fp64,fp32,fp16}_active
Unsupported fields (Status != 0 or FP64 sentinel) are warned once per device and excluded.

Tradeoffs / new deps:
- PerfWorks exclusivity: ncu and CUPTI Profiling API on the same GPU fail while enabled. CUPTI Callback API (Parca GPU kernel-launch tracing) is unaffected.
- go-dcgm is real cgo (unlike go-nvml's purego): CGO is now required on amd64 too, and the binary needs libdcgm.so on the host. Darwin can't compile go-dcgm, so the code is behind a Linux build tag with a stub for other platforms.
- New: github.com/NVIDIA/go-dcgm; libdcgm.so* copied at image build from nvcr.io/nvidia/cloud-native/dcgm:3.3.9-1-ubuntu22.04 (~8 MB delta).