### PR TITLE
Fix wall-clock timestamps on NVML sample-based metrics

### DIFF
--- a/nvidia.go
+++ b/nvidia.go
@@ -389,6 +389,7 @@ func (ds *perDeviceState) collectUtilization() error {
 		return samples[i].TimeStamp < samples[j].TimeStamp
 	})
 
+	offsetNanos := nvmlSampleOffsetNanos(time.Now(), samples)
 	for _, s := range samples {
 		value := getValue(s.SampleValue).(int64)
 
@@ -404,7 +405,7 @@ func (ds *perDeviceState) collectUtilization() error {
 		dp := g.DataPoints().AppendEmpty()
 		dp.Attributes().PutStr(attributeUUID, ds.uuid)
 		dp.Attributes().PutInt(attributeIndex, int64(ds.index))
-		dp.SetTimestamp(pcommon.Timestamp(s.TimeStamp * 1000)) // micros to nanos
+		dp.SetTimestamp(pcommon.Timestamp(int64(s.TimeStamp)*1000 + offsetNanos))
 		dp.SetIntValue(value)
 	}
 
@@ -436,6 +437,7 @@ func (ds *perDeviceState) collectMemoryUtilization() error {
 		return samples[i].TimeStamp < samples[j].TimeStamp
 	})
 
+	offsetNanos := nvmlSampleOffsetNanos(time.Now(), samples)
 	for _, s := range samples {
 		value := getValue(s.SampleValue).(int64)
 
@@ -450,7 +452,7 @@ func (ds *perDeviceState) collectMemoryUtilization() error {
 		dp := g.DataPoints().AppendEmpty()
 		dp.Attributes().PutStr(attributeUUID, ds.uuid)
 		dp.Attributes().PutInt(attributeIndex, int64(ds.index))
-		dp.SetTimestamp(pcommon.Timestamp(s.TimeStamp * 1000)) // micros to nanos
+		dp.SetTimestamp(pcommon.Timestamp(int64(s.TimeStamp)*1000 + offsetNanos))
 		dp.SetIntValue(value)
 	}
 
@@ -598,6 +600,7 @@ func (ds *perDeviceState) collectPowerConsumption() error {
 		return samples[i].TimeStamp < samples[j].TimeStamp
 	})
 
+	offsetNanos := nvmlSampleOffsetNanos(time.Now(), samples)
 	for _, s := range samples {
 		if s.TimeStamp == 0 {
 			continue
@@ -615,7 +618,7 @@ func (ds *perDeviceState) collectPowerConsumption() error {
 		dp := g.DataPoints().AppendEmpty()
 		dp.Attributes().PutStr(attributeUUID, ds.uuid)
 		dp.Attributes().PutInt(attributeIndex, int64(ds.index))
-		dp.SetTimestamp(pcommon.Timestamp(s.TimeStamp * 1000)) // micros to nanos
+		dp.SetTimestamp(pcommon.Timestamp(int64(s.TimeStamp)*1000 + offsetNanos))
 		dp.SetIntValue(value)
 	}
 
@@ -688,6 +691,25 @@ func (ds *perDeviceState) collectPCIThroughput() error {
 	}
 
 	return nil
+}
+
+// nvmlSampleOffsetNanos returns the offset in nanoseconds to add to an NVML
+// sample timestamp (microseconds against an unspecified reference clock —
+// typically CLOCK_BOOTTIME on Linux drivers) to convert it to wall-clock
+// nanoseconds since the Unix epoch. It assumes the most recent sample's
+// timestamp is approximately "now" in NVML's clock and anchors against
+// wallNow. Returns 0 if there are no usable samples.
+func nvmlSampleOffsetNanos(wallNow time.Time, samples []nvml.Sample) int64 {
+	var maxTs uint64
+	for _, s := range samples {
+		if s.TimeStamp > maxTs {
+			maxTs = s.TimeStamp
+		}
+	}
+	if maxTs == 0 {
+		return 0
+	}
+	return wallNow.UnixNano() - int64(maxTs)*1000
 }
 
 func valueGetter(sampleType nvml.ValueType) (func([8]byte) any, error) {


### PR DESCRIPTION
NVML's `GetSamples` returns each sample's `TimeStamp` as microseconds against an unspecified reference clock. On Linux drivers this is typically `CLOCK_BOOTTIME`, not the Unix epoch, so on a host with ~58 days of uptime our utilization, memory utilization, and power consumption datapoints landed in February 1970. Any time-windowed query in the UI filtered them out, which is why the GPU metrics panel rendered "No metrics data available" while `useHasGPUData` (no time filter) still said data existed.

The fix anchors each batch by treating the most recent sample's NVML timestamp as "now" against `time.Now()` and applies that offset to every datapoint, so sub-second spacing within a batch is preserved. The `lastSeenTimeStamp` we hand back to NVML still uses the original microsecond value so dedup keeps working.

Worth noting: `gpu_power_watt` shared the same bug but wasn't called out in the original report (only `gpu_power_limit_watt` was queried, and that one is stamped via `time.Now()` in `Produce()`). The PCIe throughput "0 rows" symptom from the same investigation is unrelated and still open.